### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -917,7 +917,7 @@
       <dependency>
         <groupId>net.java.dev.jna</groupId>
         <artifactId>jna</artifactId>
-        <version>5.6.0</version>
+        <version>5.7.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.lucene</groupId>


### PR DESCRIPTION
Addresses #12676

Previously, starting neo4j with JNA 5.6.0 would fail with using malloc from JNA. JNA 5.7.0 supports Apple Silicon via https://github.com/java-native-access/jna/pull/1297